### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/upload_to_dune.yml
+++ b/.github/workflows/upload_to_dune.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - 'uploads/**'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/bitcoin-core-27.0.0-RPC/security/code-scanning/2](https://github.com/roseteromeo56/bitcoin-core-27.0.0-RPC/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so token scopes are fixed to least privilege.  
Best fix here (without changing behavior) is to set workflow-level permissions to read-only content access, which is sufficient for `actions/checkout` and does not grant unnecessary write scopes.

**File to change:** `.github/workflows/upload_to_dune.yml`  
**Region:** near the top-level keys, after `on:` block and before `jobs:` (or at job level under `build:`).  
**Change needed:** add:

```yml
permissions:
  contents: read
```

No imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
