### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/push_to_dune.yml
+++ b/.github/workflows/push_to_dune.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - 'queries/**'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/bitcoin-core-27.0.0-RPC/security/code-scanning/1](https://github.com/roseteromeo56/bitcoin-core-27.0.0-RPC/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged.  
Best fix here: set workflow-level permissions to `contents: read`, which is sufficient for `actions/checkout` and does not change current functionality.

**File to change:** `.github/workflows/push_to_dune.yml`  
**Region:** near the top-level keys, after `on:` block and before `jobs:`.  
**No imports/dependencies/methods needed** (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
